### PR TITLE
Enable host.docker.internal to be working in Linux

### DIFF
--- a/meltano_projects/jaffle_superset/analyze/superset/docker-compose.yml
+++ b/meltano_projects/jaffle_superset/analyze/superset/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       - 8088:8088
     depends_on: *superset-depends-on
     volumes: *superset-volumes
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   superset-init:
     image: *superset-image
@@ -63,6 +65,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   superset-worker:
     image: *superset-image
@@ -73,6 +77,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   superset-worker-beat:
     image: *superset-image
@@ -83,6 +89,8 @@ services:
     depends_on: *superset-depends-on
     user: "root"
     volumes: *superset-volumes
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   superset_home:


### PR DESCRIPTION
This works fine in macOS Docker Desktop, but not in Linux Docker Engine
by default, due to not being resolvable, this is the mitigation to make it
work in both cases, while the limitation is it has to be in docker-engine
version v20.10 or newer.

ref https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal/67158212#67158212